### PR TITLE
Remove superfluos error and write 'Unauthorized' message only once

### DIFF
--- a/gateway/middleware.go
+++ b/gateway/middleware.go
@@ -38,10 +38,8 @@ func (a Authentication) Wrap(next http.Handler) http.Handler {
 		} else {
 			level.Debug(logger).Log("msg", "No valid tenant credentials are found")
 			sr.Header().Set("WWW-Authenticate", `Basic realm="Restricted"`)
-			sr.WriteHeader(http.StatusUnauthorized)
+			http.Error(sr, "Unauthorized", http.StatusUnauthorized)
 		}
-
-		w.WriteHeader(sr.Status)
 	})
 }
 


### PR DESCRIPTION
This PR resolves #8.

Now, the code does not throw superflous error and does not write `Unauthorized` three times. Since the error threw was caused from calling `WriteHeader()` twice, we saw logs from Golang's default logger. Therefore, that issue is not valid and was not addressed in this PR.