### PR TITLE
Add Admin endpoint to the gateway

### DIFF
--- a/gateway/config.go
+++ b/gateway/config.go
@@ -7,8 +7,9 @@ import (
 )
 
 type Config struct {
-	Server      Server   `yaml:"server"`
-	Tenants     []Tenant `yaml:"tenants"`
+	Server      NetworkAddress `yaml:"server"`
+	Admin       NetworkAddress `yaml:"admin"`
+	Tenants     []Tenant       `yaml:"tenants"`
 	Distributor struct {
 		URL   string   `yaml:"url"`
 		Paths []string `yaml:"paths"`
@@ -19,7 +20,7 @@ type Config struct {
 	} `yaml:"frontend"`
 }
 
-type Server struct {
+type NetworkAddress struct {
 	Address string `yaml:"address"`
 	Port    int    `yaml:"port"`
 }

--- a/gateway/config_test.go
+++ b/gateway/config_test.go
@@ -18,9 +18,13 @@ func TestInit(t *testing.T) {
 			name:     "Valid input file",
 			filePath: "testdata/valid.yaml",
 			configFile: Config{
-				Server: Server{
+				Server: NetworkAddress{
 					Address: "localhost",
 					Port:    8080,
+				},
+				Admin: NetworkAddress{
+					Address: "localhost",
+					Port:    8081,
 				},
 				Tenants: []Tenant{
 					{

--- a/gateway/testdata/valid.yaml
+++ b/gateway/testdata/valid.yaml
@@ -1,6 +1,9 @@
 server:
   address: localhost
   port: 8080
+admin:
+  address: localhost
+  port: 8081
 tenants:
   - authentication: basic
     username: user1

--- a/main.go
+++ b/main.go
@@ -27,7 +27,8 @@ func main() {
 		HTTPMiddleware: []middleware.Interface{
 			gateway.NewAuthentication(&conf),
 		},
-		UnAuthorizedHTTPListenPort: 6666,
+		UnAuthorizedHTTPListenAddr: conf.Admin.Address,
+		UnAuthorizedHTTPListenPort: conf.Admin.Port,
 	}
 	server, err := server.New(serverConf)
 	gateway.CheckErr("initializing the server", err)


### PR DESCRIPTION
This PR resolves #10.

Previously, we did not read the address and the port number from the configuration file for the admin endpoint, ie. unauthorized endpoint. With this PR, we read those information from the configuration file