### PR TITLE
Check the provided port in the configuration

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -316,7 +316,7 @@ func TestStartGateway(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			gw, err := createMockGateway("localhost", 8080, 8081, tc.config)
+			gw, err := createMockGateway("localhost", 8010, 8011, tc.config)
 			if tc.expectedErr == nil && err != nil {
 				t.Fatalf("Unexpected error when creating the gateway: %v\n", err)
 			}

--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -14,7 +14,12 @@ import (
 )
 
 func TestNewGateway(t *testing.T) {
-	srv, err := server.New(server.Config{})
+	srv, err := server.New(server.Config{
+		HTTPListenAddr:             "localhost",
+		HTTPListenPort:             1234,
+		UnAuthorizedHTTPListenAddr: "localhost",
+		UnAuthorizedHTTPListenPort: 1235,
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -44,6 +49,7 @@ func TestNewGateway(t *testing.T) {
 	}
 
 	assert.NotNil(t, gw)
+	srv.Shutdown()
 }
 
 func TestStartGateway(t *testing.T) {

--- a/server/server.go
+++ b/server/server.go
@@ -18,9 +18,11 @@ import (
 )
 
 const (
-	AUTH           = "auth"
-	UNAUTH         = "unauth"
-	DefaultNetwork = "tcp"
+	AUTH              = "auth"
+	UNAUTH            = "unauth"
+	DefaultNetwork    = "tcp"
+	DefaultAuthPort   = 8082
+	DefaultUnauthPort = 8081
 )
 
 type Config struct {
@@ -58,7 +60,12 @@ type server struct {
 }
 
 func initAuthServer(cfg *Config, middlewares []middleware.Interface) (*server, error) {
-	listenAddr := fmt.Sprintf("%s:%d", cfg.HTTPListenAddr, cfg.HTTPListenPort)
+	port, err := checkPort(cfg.HTTPListenAddr, cfg.HTTPListenPort, DefaultAuthPort, DefaultNetwork)
+	if err != nil {
+		return nil, err
+	}
+	cfg.HTTPListenPort = port
+	listenAddr := fmt.Sprintf("%s:%d", cfg.HTTPListenAddr, port)
 	httpListener, err := net.Listen(DefaultNetwork, listenAddr)
 	if err != nil {
 		return nil, err
@@ -115,6 +122,11 @@ func initAuthServer(cfg *Config, middlewares []middleware.Interface) (*server, e
 }
 
 func initUnAuthServer(cfg *Config, middlewares []middleware.Interface) (*server, error) {
+	port, err := checkPort(cfg.UnAuthorizedHTTPListenAddr, cfg.UnAuthorizedHTTPListenPort, DefaultUnauthPort, DefaultNetwork)
+	if err != nil {
+		return nil, err
+	}
+	cfg.UnAuthorizedHTTPListenPort = port
 	listenAddr := fmt.Sprintf("%s:%d", cfg.UnAuthorizedHTTPListenAddr, cfg.UnAuthorizedHTTPListenPort)
 	unauthHttpListener, err := net.Listen(DefaultNetwork, listenAddr)
 	if err != nil {
@@ -222,7 +234,7 @@ func New(cfg Config) (*Server, error) {
 }
 
 func (s *Server) Run() error {
-	logrus.Infof("the server has started listening on %v", s.authServer.httpServer.Addr)
+	logrus.Infof("the main server has started listening on %v", s.authServer.httpServer.Addr)
 	errChan := make(chan error, 1)
 
 	go func() {
@@ -237,6 +249,7 @@ func (s *Server) Run() error {
 		}
 	}()
 
+	logrus.Infof("the admin server has started listening on %v", s.unAuthServer.httpServer.Addr)
 	go func() {
 		err := s.unAuthServer.run()
 		if err == http.ErrServerClosed {
@@ -291,4 +304,26 @@ func (s *Server) readyHandler(w http.ResponseWriter, r *http.Request) {
 
 func (s *Server) GetHTTPHandlers() (http.Handler, http.Handler) {
 	return s.authServer.http, s.unAuthServer.http
+}
+
+func checkPortAvailable(addr string, port int, network string) bool {
+	l, err := net.Listen(network, fmt.Sprintf("%s:%d", addr, port))
+	if err != nil {
+		return false
+	}
+	l.Close()
+	return true
+}
+
+func checkPort(addr string, port int, defaultPort int, network string) (int, error) {
+	p := port
+	if port == 0 {
+		logrus.Info(fmt.Sprintf("port not specified, trying default port %d", defaultPort))
+		if checkPortAvailable(addr, defaultPort, network) {
+			p = defaultPort
+		} else {
+			return 0, fmt.Errorf(fmt.Sprintf("port %d is not available, please specify a port", defaultPort))
+		}
+	}
+	return p, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -21,7 +21,7 @@ const (
 	AUTH              = "auth"
 	UNAUTH            = "unauth"
 	DefaultNetwork    = "tcp"
-	DefaultAuthPort   = 8082
+	DefaultAuthPort   = 80
 	DefaultUnauthPort = 8081
 )
 

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -102,6 +102,7 @@ func TestNew(t *testing.T) {
 					t.Errorf("Expected server address to be %s:%d, but got %s", tc.config.HTTPListenAddr, tc.config.HTTPListenPort, server.authServer.httpServer.Addr)
 				}
 			}
+			server.Shutdown()
 		})
 	}
 }
@@ -123,7 +124,6 @@ func TestServer_RegisterTo(t *testing.T) {
 	s.RegisterTo("/test_auth", testHandler, AUTH)
 	s.RegisterTo("/test_unauth", testHandler, UNAUTH)
 
-	// Test authorized server.
 	req := httptest.NewRequest(http.MethodGet, "/test_auth", nil)
 	w := httptest.NewRecorder()
 
@@ -134,7 +134,6 @@ func TestServer_RegisterTo(t *testing.T) {
 		t.Errorf("Expected status code %d for AUTH server, but got %d", http.StatusOK, resp.StatusCode)
 	}
 
-	// Test unauthorized server.
 	req = httptest.NewRequest(http.MethodGet, "/test_unauth", nil)
 	w = httptest.NewRecorder()
 
@@ -235,6 +234,10 @@ func TestRun(t *testing.T) {
 
 func TestReadyHandler(t *testing.T) {
 	cfg := Config{
+		HTTPListenAddr:                "localhost",
+		HTTPListenPort:                1234,
+		UnAuthorizedHTTPListenAddr:    "localhost",
+		UnAuthorizedHTTPListenPort:    1235,
 		HTTPServerReadTimeout:         5 * time.Second,
 		HTTPServerWriteTimeout:        5 * time.Second,
 		HTTPServerIdleTimeout:         5 * time.Second,
@@ -286,6 +289,7 @@ func TestReadyHandler(t *testing.T) {
 			}
 		})
 	}
+	s.Shutdown()
 }
 
 func TestCheckPortAvailable(t *testing.T) {


### PR DESCRIPTION
With this PR, if the user does not provide port for the admin server and/or the main server, we will use the default ports 8081, 80, respectively. If these ports are not available, we log an error message and terminate the program.